### PR TITLE
merge proxies

### DIFF
--- a/packages/alpinejs/src/scope.ts
+++ b/packages/alpinejs/src/scope.ts
@@ -86,7 +86,7 @@ const proxyMerger: ProxyHandler<wrappedProxy> = {
     return Reflect.set(
       proxies.objects.find((obj) =>
         Object.prototype.hasOwnProperty.call(obj, name)
-      ) ?? {},
+      ) ?? proxies.objects.at(-1),
       name,
       value
     );

--- a/packages/alpinejs/src/scope.ts
+++ b/packages/alpinejs/src/scope.ts
@@ -58,8 +58,12 @@ export const mergeProxies = (objects: Record<string, unknown>[]) => {
     {
       ownKeys: () =>
         Array.from(new Set(objects.flatMap((i) => Object.keys(i)))),
-      has: (_, name) =>
-        objects.some((obj) => Object.prototype.hasOwnProperty.call(obj, name)),
+      has: (_, name) => {
+        if (name == Symbol.unscopables) return false;
+        return objects.some((obj) =>
+          Object.prototype.hasOwnProperty.call(obj, name)
+        );
+      },
       get: (_, name) => {
         if (name == 'toJSON') return collapseProxies;
         return Reflect.get(

--- a/size.json
+++ b/size.json
@@ -2,11 +2,11 @@
   "alpinejs": {
     "minified": {
       "pretty": "38.7 kB",
-      "raw": 38670
+      "raw": 38684
     },
     "brotli": {
       "pretty": "13.2 kB",
-      "raw": 13162
+      "raw": 13168
     }
   }
 }

--- a/size.json
+++ b/size.json
@@ -1,12 +1,12 @@
 {
   "alpinejs": {
     "minified": {
-      "pretty": "38.6 kB",
-      "raw": 38613
+      "pretty": "38.7 kB",
+      "raw": 38670
     },
     "brotli": {
       "pretty": "13.2 kB",
-      "raw": 13163
+      "raw": 13162
     }
   }
 }

--- a/size.json
+++ b/size.json
@@ -1,12 +1,12 @@
 {
   "alpinejs": {
     "minified": {
-      "pretty": "38.9 kB",
-      "raw": 38900
+      "pretty": "38.6 kB",
+      "raw": 38588
     },
     "brotli": {
-      "pretty": "13.3 kB",
-      "raw": 13291
+      "pretty": "13.2 kB",
+      "raw": 13156
     }
   }
 }

--- a/size.json
+++ b/size.json
@@ -2,11 +2,11 @@
   "alpinejs": {
     "minified": {
       "pretty": "38.6 kB",
-      "raw": 38588
+      "raw": 38613
     },
     "brotli": {
       "pretty": "13.2 kB",
-      "raw": 13156
+      "raw": 13163
     }
   }
 }

--- a/size.json
+++ b/size.json
@@ -1,12 +1,12 @@
 {
   "alpinejs": {
     "minified": {
-      "pretty": "38.8 kB",
-      "raw": 38780
+      "pretty": "38.9 kB",
+      "raw": 38900
     },
     "brotli": {
-      "pretty": "13.2 kB",
-      "raw": 13229
+      "pretty": "13.3 kB",
+      "raw": 13291
     }
   }
 }

--- a/tests/scope.test.ts
+++ b/tests/scope.test.ts
@@ -1,0 +1,23 @@
+import { mergeProxies } from '@/alpinejs/scope';
+
+describe('mergeProxies', () => {
+  it('allows getting keys from object list', () => {
+    const objects = [{ foo: 'bar' }, { baz: 'qux' }];
+    const proxy = mergeProxies(objects);
+    expect(proxy.foo).toBe('bar');
+    expect(proxy.baz).toBe('qux');
+  });
+  it('allows settings values to object list', () => {
+    const objects = [{ foo: 'bar' }, { baz: 'qux' }];
+    const proxy = mergeProxies(objects);
+    proxy.foo = 'baz';
+    expect(objects[0].foo).toBe('baz');
+    proxy.baz = 'bar';
+    expect(objects[1].baz).toBe('bar');
+  });
+  it('allows JSON Stringification', () => {
+    const objects = [{ foo: 'bar' }, { baz: 'qux' }];
+    const proxy = mergeProxies(objects);
+    expect(JSON.stringify(proxy)).toBe('{"foo":"bar","baz":"qux"}');
+  });
+});


### PR DESCRIPTION
- :construction: Allows stringification
- :recycle: Uses Reflection
- :zap: Short circuit on unscopables
- :recycle: Extracts proxy handler
